### PR TITLE
[WIP] [Relay] Better relay provided props

### DIFF
--- a/types/react-relay/classic.d.ts
+++ b/types/react-relay/classic.d.ts
@@ -117,7 +117,7 @@ export class DefaultNetworkLayer implements RelayNetworkLayer {
 }
 
 export function createContainer<T>(
-    component: React.ComponentClass<T> | React.StatelessComponent<T>,
+    component: React.ComponentType<T>,
     params?: CreateContainerOpts
 ): RelayContainerClass<T>;
 export function injectNetworkLayer(networkLayer: RelayNetworkLayer): any;

--- a/types/react-relay/compat.d.ts
+++ b/types/react-relay/compat.d.ts
@@ -1,12 +1,8 @@
-export {
-    QueryRenderer,
-    fetchQuery,
-    graphql,
-} from "./index";
+export { QueryRenderer, fetchQuery, graphql } from "./index";
 import {
     ConnectionConfig,
     RelayPaginationProp as RelayModernPaginationProp,
-    RelayRefetchProp as RelayModernRefetchProp
+    RelayRefetchProp as RelayModernRefetchProp,
 } from "./index";
 import * as RelayRuntimeTypes from "relay-runtime";
 import { RelayEnvironmentInterface } from "./classic";

--- a/types/react-relay/compat.d.ts
+++ b/types/react-relay/compat.d.ts
@@ -26,7 +26,6 @@ export interface StatelessWithFragment<T> extends React.StatelessComponent<T> {
     getFragment: typeof getFragment;
 }
 export type ReactFragmentComponent<T> = ComponentWithFragment<T> | StatelessWithFragment<T>;
-export type ReactBaseComponent<T> = React.ComponentClass<T> | React.StatelessComponent<T>;
 export type RelayClassicEnvironment = RelayEnvironmentInterface;
 
 // ~~~~~~~~~~~~~~~~~~~~~
@@ -64,18 +63,18 @@ export interface GeneratedNodeMap {
 }
 
 export function createFragmentContainer<T>(
-    Component: ReactBaseComponent<T>,
+    Component: React.ComponentType<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap
 ): ReactFragmentComponent<T>;
 
 export function createRefetchContainer<T>(
-    Component: ReactBaseComponent<T>,
+    Component: React.ComponentType<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap,
     taggedNode: RelayRuntimeTypes.GraphQLTaggedNode
 ): ReactFragmentComponent<T>;
 
 export function createPaginationContainer<T>(
-    Component: ReactBaseComponent<T>,
+    Component: React.ComponentType<T>,
     fragmentSpec: RelayRuntimeTypes.GraphQLTaggedNode | GeneratedNodeMap,
     connectionConfig: ConnectionConfig<T>
 ): ReactFragmentComponent<T>;

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -23,7 +23,6 @@ export type ConcreteFragment = any;
 export type ConcreteBatch = any;
 export type ConcreteFragmentDefinition = object;
 export type ConcreteOperationDefinition = object;
-export type ReactBaseComponent<T> = React.ComponentClass<T> | React.StatelessComponent<T>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // RelayProp
@@ -86,9 +85,9 @@ export class QueryRenderer extends ReactRelayQueryRenderer {}
 // createFragmentContainer
 // ~~~~~~~~~~~~~~~~~~~~~
 export function createFragmentContainer<T>(
-    Component: ReactBaseComponent<T>,
+    Component: React.ComponentType<T>,
     fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap
-): ReactBaseComponent<T>;
+): React.ComponentType<T>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // createPaginationContainer
@@ -133,13 +132,13 @@ export interface ConnectionConfig<T> {
     query: GraphQLTaggedNode;
 }
 export function createPaginationContainer<T>(
-    Component: ReactBaseComponent<T>,
+    Component: React.ComponentType<T>,
     fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
     connectionConfig: ConnectionConfig<T>
-): ReactBaseComponent<T>;
+): React.ComponentType<T>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
-// createFragmentContainer
+// createRefetchContainer
 // ~~~~~~~~~~~~~~~~~~~~~
 export interface RefetchOptions {
     force?: boolean;
@@ -156,7 +155,7 @@ export type RelayRefetchProp = RelayProp & {
     ): RelayRuntimeTypes.Disposable;
 };
 export function createRefetchContainer<T>(
-    Component: ReactBaseComponent<T>,
+    Component: React.ComponentType<T>,
     fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
     taggedNode: GraphQLTaggedNode
-): ReactBaseComponent<T>;
+): React.ComponentType<T>;

--- a/types/react-relay/index.d.ts
+++ b/types/react-relay/index.d.ts
@@ -19,7 +19,6 @@ import * as RelayRuntimeTypes from "relay-runtime";
 // ~~~~~~~~~~~~~~~~~~~~~
 // Maybe Fix
 // ~~~~~~~~~~~~~~~~~~~~~
-export type ConcreteFragment = any;
 export type ConcreteBatch = any;
 export type ConcreteFragmentDefinition = object;
 export type ConcreteOperationDefinition = object;
@@ -44,9 +43,9 @@ export interface GeneratedNodeMap {
     [key: string]: GraphQLTaggedNode;
 }
 export type GraphQLTaggedNode =
-    | (() => ConcreteFragment | ConcreteBatch)
+    | (() => RelayRuntimeTypes.ConcreteFragment | ConcreteBatch)
     | {
-          modern(): ConcreteFragment | ConcreteBatch;
+          modern(): RelayRuntimeTypes.ConcreteFragment | ConcreteBatch;
           classic(relayQL: typeof RelayQL): ConcreteFragmentDefinition | ConcreteOperationDefinition;
       };
 /**
@@ -82,12 +81,69 @@ export class ReactRelayQueryRenderer extends React.Component<QueryRendererProps,
 export class QueryRenderer extends ReactRelayQueryRenderer {}
 
 // ~~~~~~~~~~~~~~~~~~~~~
+// Container utilities
+// ~~~~~~~~~~~~~~~~~~~~~
+
+type AnyRelayProp = { relay: any };
+
+// These get emitted by relay-compiler
+export interface AbstractFragment {
+    __fragments: AbstractFragment;
+}
+
+// Turn all the properties in `F` to be of type `AbstractFragment` or `AbstractFragment[]` for @relay(plural: true)
+type AbstractFragments<F extends GeneratedNodeMap> = { [P in keyof F]: AbstractFragment | ReadonlyArray<AbstractFragment> }
+
+// Taken from https://github.com/pelotom/type-zoo
+type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T]
+type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>
+type Overwrite<T, U> = Omit<T, Diff<keyof T, Diff<keyof T, keyof U>>> & U
+
+// Remove a RelayProp/RelayRefetchProp/RelayPaginationProp
+type OmitRelayProp<P extends AnyRelayProp> = Omit<P, "relay">;
+
+// Turn all properties in P that exist in `F` to abstract fragments
+type OmitFragmentProps<P, F extends GeneratedNodeMap> = Overwrite<P, AbstractFragments<F>>
+
+// ~~~~~~~~~~~~~~~~~~~~~
+// Container types
+// ~~~~~~~~~~~~~~~~~~~~~
+
+type ContainerWithFragmentAndRelayProps<P extends AnyRelayProp, F extends GeneratedNodeMap> =
+    React.ComponentType<OmitFragmentProps<OmitRelayProp<P>, F>>;
+
+type ContainerWithFragmentProps<P, F extends GeneratedNodeMap> =
+    React.ComponentType<OmitFragmentProps<P, F>>;
+
+type ContainerWithRelayProp<P extends AnyRelayProp> =
+    React.ComponentType<OmitRelayProp<P>>;
+
+type Container<P> =
+    React.ComponentType<P>;
+
+// ~~~~~~~~~~~~~~~~~~~~~
 // createFragmentContainer
 // ~~~~~~~~~~~~~~~~~~~~~
-export function createFragmentContainer<T>(
-    Component: React.ComponentType<T>,
-    fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap
-): React.ComponentType<T>;
+
+export function createFragmentContainer<P extends AnyRelayProp, F extends GeneratedNodeMap>(
+    Component: React.ComponentType<P>,
+    fragmentSpec: F
+): ContainerWithFragmentAndRelayProps<P, F>
+
+export function createFragmentContainer<P, F extends GeneratedNodeMap>(
+    Component: React.ComponentType<P>,
+    fragmentSpec: F
+): ContainerWithFragmentProps<P, F>
+
+export function createFragmentContainer<P extends AnyRelayProp>(
+    Component: React.ComponentType<P>,
+    fragmentSpec: GraphQLTaggedNode
+): ContainerWithRelayProp<P>;
+
+export function createFragmentContainer<P>(
+    Component: React.ComponentType<P>,
+    fragmentSpec: GraphQLTaggedNode
+): Container<P>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // createPaginationContainer
@@ -131,19 +187,40 @@ export interface ConnectionConfig<T> {
     ): RelayRuntimeTypes.Variables;
     query: GraphQLTaggedNode;
 }
-export function createPaginationContainer<T>(
-    Component: React.ComponentType<T>,
-    fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
-    connectionConfig: ConnectionConfig<T>
-): React.ComponentType<T>;
+
+export function createPaginationContainer<P extends AnyRelayProp, F extends GeneratedNodeMap>(
+    Component: React.ComponentType<P>,
+    fragmentSpec: F,
+    connectionConfig: ConnectionConfig<P>
+): ContainerWithFragmentAndRelayProps<P, F>;
+
+export function createPaginationContainer<P, F extends GeneratedNodeMap>(
+    Component: React.ComponentType<P>,
+    fragmentSpec: F,
+    connectionConfig: ConnectionConfig<P>
+): ContainerWithFragmentProps<P, F>;
+
+export function createPaginationContainer<P extends AnyRelayProp>(
+    Component: React.ComponentType<P>,
+    fragmentSpec: GraphQLTaggedNode,
+    connectionConfig: ConnectionConfig<P>
+): ContainerWithRelayProp<P>;
+
+export function createPaginationContainer<P>(
+    Component: React.ComponentType<P>,
+    fragmentSpec: GraphQLTaggedNode,
+    connectionConfig: ConnectionConfig<P>
+): Container<P>;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // createRefetchContainer
 // ~~~~~~~~~~~~~~~~~~~~~
+
 export interface RefetchOptions {
     force?: boolean;
     rerunParamExperimental?: RelayRuntimeTypes.RerunParam;
 }
+
 export type RelayRefetchProp = RelayProp & {
     refetch(
         refetchVariables:
@@ -154,8 +231,27 @@ export type RelayRefetchProp = RelayProp & {
         options?: RefetchOptions
     ): RelayRuntimeTypes.Disposable;
 };
-export function createRefetchContainer<T>(
-    Component: React.ComponentType<T>,
-    fragmentSpec: GraphQLTaggedNode | GeneratedNodeMap,
+
+export function createRefetchContainer<P extends AnyRelayProp, F extends GeneratedNodeMap>(
+    Component: React.ComponentType<P>,
+    fragmentSpec: F,
     taggedNode: GraphQLTaggedNode
-): React.ComponentType<T>;
+): ContainerWithFragmentAndRelayProps<P, F>;
+
+export function createRefetchContainer<P, F extends GeneratedNodeMap>(
+    Component: React.ComponentType<P>,
+    fragmentSpec: F,
+    taggedNode: GraphQLTaggedNode
+): ContainerWithFragmentProps<P, F>;
+
+export function createRefetchContainer<P extends AnyRelayProp>(
+    Component: React.ComponentType<P>,
+    fragmentSpec: GraphQLTaggedNode,
+    taggedNode: GraphQLTaggedNode
+): ContainerWithRelayProp<P>;
+
+export function createRefetchContainer<P>(
+    Component: React.ComponentType<P>,
+    fragmentSpec: GraphQLTaggedNode,
+    taggedNode: GraphQLTaggedNode
+): Container<P>;

--- a/types/react-relay/test/react-relay-classic-tests.tsx
+++ b/types/react-relay/test/react-relay-classic-tests.tsx
@@ -1,15 +1,14 @@
 import * as React from "react";
 import * as Relay from "react-relay/classic";
 
+import { CompatContainer } from "./react-relay-compat-tests";
+
 interface Props {
     text: string;
     userId: string;
 }
 
-// tslint:disable-next-line no-empty-interface
-interface Response {}
-
-export default class AddTweetMutation extends Relay.Mutation<Props, Response> {
+export default class AddTweetMutation extends Relay.Mutation<Props, {}> {
     getMutation() {
         return Relay.QL`mutation{addTweet}`;
     }
@@ -61,6 +60,7 @@ const ArtworkContainer = Relay.createContainer(Artwork, {
         artwork: () => Relay.QL`
             fragment on Artwork {
                 title
+                ${CompatContainer.getFragment("whatever")}
             }
         `,
     },
@@ -80,7 +80,7 @@ class StubbedArtwork extends React.Component {
                 setVariables: () => {},
                 forceFetch: () => {},
                 hasOptimisticUpdate: () => false,
-                getPendingTransactions: (): Relay.RelayMutationTransaction[] => [],
+                getPendingTransactions: (): any => undefined,
                 commitUpdate: () => {},
             },
         };

--- a/types/react-relay/test/react-relay-compat-tests.tsx
+++ b/types/react-relay/test/react-relay-compat-tests.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import {
+    QueryRenderer as CompatQueryRenderer,
+    createFragmentContainer as createFragmentContainerCompat,
+    commitMutation as commitMutationCompat,
+    CompatEnvironment,
+    RelayPaginationProp as RelayPaginationPropCompat,
+} from "react-relay/compat";
+
+import { configs, mutation, optimisticResponse } from "./react-relay-tests";
+
+// testting compat mutation with classic environment
+function markNotificationAsReadCompat(environment: CompatEnvironment, source: string, storyID: string) {
+    const variables = {
+        input: {
+            source,
+            storyID,
+        },
+    };
+
+    commitMutationCompat(environment, {
+        configs,
+        mutation,
+        optimisticResponse,
+        variables,
+        onCompleted: (response, errors) => {
+            console.log("Response received from server.");
+        },
+        onError: err => console.error(err),
+        updater: (store, data) => {
+            const field = store.get(storyID);
+            if (field) {
+                field.setValue(data.story, "story");
+            }
+        }
+    });
+}
+
+interface CompatProps {
+    relay: RelayPaginationPropCompat;
+}
+
+class CompatComponent extends React.Component<CompatProps> {
+    markNotificationAsRead(source: string, storyID: string) {
+        markNotificationAsReadCompat(this.props.relay.environment, source, storyID);
+    }
+
+    render() {
+        return (<div/>);
+    }
+}
+
+export const CompatContainer = createFragmentContainerCompat(CompatComponent, {});

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import { Environment, Network, RecordSource, Store, ConnectionHandler } from "relay-runtime";
+import { Environment, Network, RecordSource, Store, ConnectionHandler, FragmentReference } from "relay-runtime";
 
 import {
+    AbstractFragment,
     graphql,
     commitMutation,
     createFragmentContainer,
@@ -10,7 +11,7 @@ import {
     requestSubscription,
     QueryRenderer,
     RelayRefetchProp,
-    RelayPaginationProp
+    RelayPaginationProp,
 } from "react-relay";
 
 // ~~~~~~~~~~~~~~~~~~~~~
@@ -54,114 +55,196 @@ const MyQueryRenderer = (props: { name: string }) => (
 // ~~~~~~~~~~~~~~~~~~~~~
 // Modern FragmentContainer
 // ~~~~~~~~~~~~~~~~~~~~~
-const MyFragmentContainer = createFragmentContainer(
-    class TodoListView extends React.Component {
+
+() => {
+    // relay-compiler artifact
+    interface TodoItem_item {
+        text: string;
+        isComplete: boolean;
+        __fragments: AbstractFragment;
+    }
+
+    interface Props {
+        aRequiredProp: true;
+        item: TodoItem_item;
+    }
+
+    class MyComponent extends React.Component<Props> {
         render() {
             return <div />;
         }
-    },
-    {
-        item: graphql`
-            fragment TodoItem_item on Todo {
-                text
-                isComplete
-            }
-        `,
     }
-);
+
+    const MyFragmentContainer = createFragmentContainer(
+        MyComponent,
+        {
+            item: graphql`
+                fragment TodoItem_item on Todo {
+                    text
+                    isComplete
+                }
+            `,
+        }
+    );
+
+    function shouldOnlyNeedToPassAbstractFragmentProps(item: AbstractFragment) {
+        <MyFragmentContainer aRequiredProp={true} item={item} />;
+    }
+
+    function shouldAcceptFragmentProps(item: AbstractFragment) {
+        <MyFragmentContainer aRequiredProp={true} item={item} />;
+    }
+};
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // Modern RefetchContainer
 // ~~~~~~~~~~~~~~~~~~~~~
-interface StoryInterface {
-    id: string;
-}
-interface FeedStoriesProps {
-    relay: RelayRefetchProp;
-    feed: {
-        stories: { edges: Array<{ node: StoryInterface }> };
-    };
-}
-class Story extends React.Component<{ story: StoryInterface }> {}
-class FeedStories extends React.Component<FeedStoriesProps> {
-    render() {
-        return (
-            <div>
-                {this.props.feed.stories.edges.map(edge => <Story story={edge.node} key={edge.node.id} />)}
-                <button onClick={() => this._loadMore} title="Load More" />
-            </div>
-        );
+
+() => {
+    // relay-compiler artifact
+    type Story_stories = ReadonlyArray<{
+        title: string;
+    }>;
+
+    interface StoriesProps {
+        aRequiredProp: true;
+        stories: Story_stories;
     }
 
-    _loadMore() {
-        // Increments the number of stories being rendered by 10.
-        const refetchVariables = (fragmentVariables: { count: number }) => ({
-            count: fragmentVariables.count + 10,
-        });
-        this.props.relay.refetch(refetchVariables);
-    }
-}
+    class Stories extends React.Component<StoriesProps> {}
 
-const FeedRefetchContainer = createRefetchContainer(
-    FeedStories,
-    {
-        feed: graphql.experimental`
-            fragment FeedStories_feed on Feed @argumentDefinitions(count: { type: "Int", defaultValue: 10 }) {
-                stories(first: $count) {
-                    edges {
-                        node {
-                            id
-                            ...Story_story
+    const StoriesContainer = createFragmentContainer(Stories, {
+        stories: graphql`
+            fragment Story_stories on StoryEdge @relay(plural: true) {
+                title
+            }
+        `
+    });
+
+    // relay-compiler artifact
+    interface FeedStories_feed {
+        stories: {
+            edges: Array<{
+                node: {
+                    id: string;
+                }
+                __fragments: AbstractFragment;
+            }>
+        };
+    }
+
+    interface FeedStoriesProps {
+        aRequiredProp: true;
+        relay: RelayRefetchProp;
+        feed: FeedStories_feed;
+    }
+
+    class FeedStories extends React.Component<FeedStoriesProps> {
+        render() {
+            return (
+                <div>
+                    <StoriesContainer stories={this.props.feed.stories.edges} aRequiredProp={true} />
+                    <button onClick={() => this._loadMore} title="Load More" />
+                </div>
+            );
+        }
+
+        _loadMore() {
+            // Increments the number of stories being rendered by 10.
+            const refetchVariables = (fragmentVariables: { count: number }) => ({
+                count: fragmentVariables.count + 10,
+            });
+            this.props.relay.refetch(refetchVariables);
+        }
+    }
+
+    const FeedRefetchContainer = createRefetchContainer(
+        FeedStories,
+        {
+            feed: graphql.experimental`
+                fragment FeedStories_feed on Feed @argumentDefinitions(count: { type: "Int", defaultValue: 10 }) {
+                    stories(first: $count) {
+                        edges {
+                            ...Story_stories
+                            node {
+                                id
+                            }
                         }
                     }
                 }
+            `,
+        },
+        graphql.experimental`
+            query FeedStoriesRefetchQuery($count: Int) {
+                feed {
+                    ...FeedStories_feed @arguments(count: $count)
+                }
             }
-        `,
-    },
-    graphql.experimental`
-        query FeedStoriesRefetchQuery($count: Int) {
-            feed {
-                ...FeedStories_feed @arguments(count: $count)
-            }
-        }
-    `
-);
+        `
+    );
+
+    function shouldOnlyNeedToPassAbstractFragmentProps(feed: AbstractFragment) {
+        <FeedRefetchContainer aRequiredProp={true} feed={feed} />;
+    }
+};
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // Modern PaginationContainer
 // ~~~~~~~~~~~~~~~~~~~~~
-interface FeedProps {
-    user: { feed: { edges: Array<{ node: StoryInterface }> } };
-    relay: RelayPaginationProp;
-}
-class Feed extends React.Component<FeedProps> {
-    render() {
-        return (
-            <div>
-                {this.props.user.feed.edges.map(edge => <Story story={edge.node} key={edge.node.id} />)}
-                <button onClick={() => this._loadMore()} title="Load More" />
-            </div>
-        );
+
+() => {
+    // relay-compiler artifact
+    interface Story_story {
+        title: string;
     }
 
-    _loadMore() {
-        if (!this.props.relay.hasMore() || this.props.relay.isLoading()) {
-            return;
+    interface StoryProps {
+        aRequiredProp: true;
+        story: Story_story;
+    }
+
+    class Story extends React.Component<StoryProps> {}
+
+    const StoryContainer = createFragmentContainer(Story, graphql`
+        fragment Story_story on Story {
+            title
+        }
+    `);
+
+    interface FeedProps {
+        aRequiredProp: true;
+        user: { feed: { edges: Array<{ node: { id: string } }> } };
+        relay: RelayPaginationProp;
+    }
+    class Feed extends React.Component<FeedProps> {
+        render() {
+            return (
+                <div>
+                    {this.props.user.feed.edges.map(edge => {
+                        return <StoryContainer aRequiredProp={true} story={edge.node as any} key={edge.node.id} />;
+                    })}
+                    <button onClick={() => this._loadMore()} title="Load More" />
+                </div>
+            );
         }
 
-        this.props.relay.loadMore(
-            10, // Fetch the next 10 feed items
-            e => {
-                console.log(e);
+        _loadMore() {
+            if (!this.props.relay.hasMore() || this.props.relay.isLoading()) {
+                return;
             }
-        );
-    }
-}
 
-const FeedPaginationContainer = createPaginationContainer(
-    Feed,
-    {
-        user: graphql`
+            this.props.relay.loadMore(
+                10, // Fetch the next 10 feed items
+                e => {
+                    console.log(e);
+                }
+            );
+        }
+    }
+
+    const FeedPaginationContainer = createPaginationContainer(
+        Feed,
+        graphql`
             fragment Feed_user on User {
                 feed(
                     first: $count
@@ -177,37 +260,41 @@ const FeedPaginationContainer = createPaginationContainer(
                 }
             }
         `,
-    },
-    {
-        direction: "forward",
-        getConnectionFromProps(props) {
-            return props.user && props.user.feed;
-        },
-        getFragmentVariables(prevVars, totalCount) {
-            return {
-                ...prevVars,
-                count: totalCount,
-            };
-        },
-        getVariables(props, { count, cursor }, fragmentVariables) {
-            return {
-                count,
-                cursor,
-                // in most cases, for variables other than connection filters like
-                // `first`, `after`, etc. you may want to use the previous values.
-                orderBy: fragmentVariables.orderBy,
-            };
-        },
-        query: graphql`
-            query FeedPaginationQuery($count: Int!, $cursor: String, $orderby: String!) {
-                user {
-                    # You could reference the fragment defined previously.
-                    ...Feed_user
+        {
+            direction: "forward",
+            getConnectionFromProps(props) {
+                return props.user && props.user.feed;
+            },
+            getFragmentVariables(prevVars, totalCount) {
+                return {
+                    ...prevVars,
+                    count: totalCount,
+                };
+            },
+            getVariables(props, { count, cursor }, fragmentVariables) {
+                return {
+                    count,
+                    cursor,
+                    // in most cases, for variables other than connection filters like
+                    // `first`, `after`, etc. you may want to use the previous values.
+                    orderBy: fragmentVariables.orderBy,
+                };
+            },
+            query: graphql`
+                query FeedPaginationQuery($count: Int!, $cursor: String, $orderby: String!) {
+                    user {
+                        # You could reference the fragment defined previously.
+                        ...Feed_user
+                    }
                 }
-            }
-        `,
+            `,
+        }
+    );
+
+    function shouldOnlyNeedToPassAbstractFragmentProps(user: AbstractFragment) {
+        <FeedPaginationContainer aRequiredProp={true} user={user as any} />;
     }
-);
+};
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // Modern Mutations

--- a/types/react-relay/test/react-relay-tests.tsx
+++ b/types/react-relay/test/react-relay-tests.tsx
@@ -1,9 +1,6 @@
 import * as React from "react";
 import { Environment, Network, RecordSource, Store, ConnectionHandler } from "relay-runtime";
 
-////////////////////////////
-//  RELAY MODERN TESTS
-///////////////////////////
 import {
     graphql,
     commitMutation,
@@ -215,7 +212,7 @@ const FeedPaginationContainer = createPaginationContainer(
 // ~~~~~~~~~~~~~~~~~~~~~
 // Modern Mutations
 // ~~~~~~~~~~~~~~~~~~~~~
-const mutation = graphql`
+export const mutation = graphql`
     mutation MarkReadNotificationMutation($input: MarkReadNotificationData!) {
         markReadNotification(data: $input) {
             notification {
@@ -225,7 +222,7 @@ const mutation = graphql`
     }
 `;
 
-const optimisticResponse = {
+export const optimisticResponse = {
     markReadNotification: {
         notification: {
             seenState: "SEEN",
@@ -233,7 +230,7 @@ const optimisticResponse = {
     },
 };
 
-const configs = [
+export const configs = [
     {
         type: "NODE_DELETE" as "NODE_DELETE",
         deletedIDFieldName: "destroyedShipId",
@@ -325,147 +322,3 @@ requestSubscription(
         },
     }
 );
-
-////////////////////////////
-//  RELAY COMPAT TESTS
-///////////////////////////
-import {
-    QueryRenderer as CompatQueryRenderer,
-    createFragmentContainer as createFragmentContainerCompat,
-    commitMutation as commitMutationCompat,
-    CompatEnvironment,
-    RelayPaginationProp as RelayPaginationPropCompat,
-} from "react-relay/compat";
-
-// testting compat mutation with classic environment
-function markNotificationAsReadCompat(environment: CompatEnvironment, source: string, storyID: string) {
-    const variables = {
-        input: {
-            source,
-            storyID,
-        },
-    };
-
-    commitMutationCompat(environment, {
-        configs,
-        mutation,
-        optimisticResponse,
-        variables,
-        onCompleted: (response, errors) => {
-            console.log("Response received from server.");
-        },
-        onError: err => console.error(err),
-        updater: (store, data) => {
-            const field = store.get(storyID);
-            if (field) {
-                field.setValue(data.story, "story");
-            }
-        }
-    });
-}
-
-interface CompatProps {
-    relay: RelayPaginationPropCompat;
-}
-
-export class CompatComponent extends React.Component<CompatProps> {
-    markNotificationAsRead(source: string, storyID: string) {
-        markNotificationAsReadCompat(this.props.relay.environment, source, storyID);
-    }
-
-    render() {
-        return (<div/>);
-    }
-}
-
-const CompatContainer = createFragmentContainerCompat(CompatComponent, {});
-
-////////////////////////////
-//  RELAY-CLASSIC TESTS
-///////////////////////////
-import * as Relay from "react-relay/classic";
-
-interface Props {
-    text: string;
-    userId: string;
-}
-
-export default class AddTweetMutation extends Relay.Mutation<Props, {}> {
-    getMutation() {
-        return Relay.QL`mutation{addTweet}`;
-    }
-
-    getFatQuery() {
-        return Relay.QL`
-            fragment on AddTweetPayload {
-                tweetEdge
-                user
-            }
-        `;
-    }
-
-    getConfigs() {
-        return [
-            {
-                type: "RANGE_ADD",
-                parentName: "user",
-                parentID: this.props.userId,
-                connectionName: "tweets",
-                edgeName: "tweetEdge",
-                rangeBehaviors: {
-                    "": "append",
-                },
-            },
-        ];
-    }
-
-    getVariables() {
-        return this.props;
-    }
-}
-
-interface ArtworkProps {
-    artwork: {
-        title: string;
-    };
-    relay: Relay.RelayProp;
-}
-
-class Artwork extends React.Component<ArtworkProps> {
-    render() {
-        return <a href={`/artworks/${this.props.relay.variables.artworkID}`}>{this.props.artwork.title}</a>;
-    }
-}
-
-const ArtworkContainer = Relay.createContainer(Artwork, {
-    fragments: {
-        artwork: () => Relay.QL`
-            fragment on Artwork {
-                title
-                ${ CompatContainer.getFragment('whatever') }
-            }
-        `,
-    },
-});
-
-class StubbedArtwork extends React.Component {
-    render() {
-        const props = {
-            artwork: { title: "CHAMPAGNE FORMICA FLAG" },
-            relay: {
-                route: {
-                    name: "champagne",
-                },
-                variables: {
-                    artworkID: "champagne-formica-flag",
-                },
-                setVariables: () => {},
-                forceFetch: () => {},
-                hasOptimisticUpdate: () => false,
-                getPendingTransactions: (): any => undefined,
-                commitUpdate: () => {},
-            },
-        };
-        return <ArtworkContainer {...props} />;
-    }
-}

--- a/types/react-relay/tsconfig.json
+++ b/types/react-relay/tsconfig.json
@@ -23,6 +23,7 @@
         "classic.d.ts",
         "compat.d.ts",
         "test/react-relay-tests.tsx",
+        "test/react-relay-compat-tests.tsx",
         "test/react-relay-classic-tests.tsx"
     ]
 }

--- a/types/relay-runtime/index.d.ts
+++ b/types/relay-runtime/index.d.ts
@@ -17,7 +17,6 @@ export type RelayConcreteNode = any;
 export type RelayMutationTransaction = any;
 export type RelayMutationRequest = any;
 export type RelayQueryRequest = any;
-export type ConcreteFragment = any;
 export type ConcreteBatch = any;
 export type ConcreteFragmentDefinition = object;
 export type ConcreteOperationDefinition = object;
@@ -31,6 +30,19 @@ export type ConcreteOperationDefinition = object;
  * but have no definition in Relay's types. Suppressing for now.
  */
 export type RelayContainer = any;
+
+// ~~~~~~~~~~~~~~~~~~~~~
+// Used in artifacts
+// emitted by
+// relay-compiler
+// ~~~~~~~~~~~~~~~~~~~~~
+// File: https://github.com/facebook/relay/blob/fe0e70f10bbcba1fff89911313ea69f24569464b/packages/relay-runtime/util/RelayConcreteNode.js
+export type ConcreteFragment = any;
+export type ConcreteRequest = any;
+export type ConcreteBatchRequest = any;
+
+// File: https://github.com/facebook/relay/blob/fe0e70f10bbcba1fff89911313ea69f24569464b/packages/relay-runtime/store/RelayStoreTypes.js#L47
+export type FragmentReference = never;
 
 // ~~~~~~~~~~~~~~~~~~~~~
 // RelayQL

--- a/types/relay-runtime/relay-runtime-tests.tsx
+++ b/types/relay-runtime/relay-runtime-tests.tsx
@@ -1,4 +1,12 @@
-import { Environment, Network, RecordSource, Store, ConnectionHandler, ViewerHandler, RecordSourceInspector } from "relay-runtime";
+import {
+    Environment,
+    Network,
+    RecordSource,
+    Store,
+    ConnectionHandler,
+    ViewerHandler,
+    RecordSourceInspector,
+} from "relay-runtime";
 
 const source = new RecordSource();
 const store = new Store(source);


### PR DESCRIPTION
Here’s the WIP code I had for the DT typings based on the progress I had made previously. It does a few things:

* Removes the `this.props.relay` prop from the external component props typing.

* Recasts data props to opaque ‘fragment reference’ types in the external component props typing. In order to do this, you _have_ to use a `GeneratedNodeMap` rather than a `GraphQLTaggedNode`, because it allows the TS type system to inflect on the prop names. This is why there are now 4 overloads per container factory function.

The only thing I had not been able to figure out yet was a way to narrow the opaque fragment references such that you can _only_ pass the correct opaque data to the relay container, so in this PR all opaque fragment references are equal.

@kastermester I think you said you had figured out a way to be able to do that, though?